### PR TITLE
Fix php_extensions and update nodejs version

### DIFF
--- a/deployment/tasks_phpextensions.yml
+++ b/deployment/tasks_phpextensions.yml
@@ -1,6 +1,6 @@
 - name: LAMP | Install php extensions
   apt: pkg={{ item.name }} state=latest force=yes update_cache=yes
   with_items: "{{ php_extensions }}"
-  sudo: yes
+  become: yes
   tags:
     - php

--- a/deployment/tasks_phpextensions.yml
+++ b/deployment/tasks_phpextensions.yml
@@ -1,6 +1,6 @@
 - name: LAMP | Install php extensions
   apt: pkg={{ item.name }} state=latest force=yes update_cache=yes
-  with_items: php_extensions
+  with_items: "{{ php_extensions }}"
   sudo: yes
   tags:
     - php

--- a/deployment/vagrant.yml
+++ b/deployment/vagrant.yml
@@ -9,7 +9,7 @@
     java_version: 8
     mailhog_version: 0.1.6
     mongo_version: 3
-    nodejs_version: "0.12" # 0.10 0.12
+    nodejs_version: "6.x" # 0.10 0.12 4.x 5.x 6.x 7.x
     php_family: default # 5.4 | 5.5 | 5.6 | default
     php_xdebug_version: 2.3.3
 

--- a/deployment/vagrant.yml
+++ b/deployment/vagrant.yml
@@ -25,8 +25,8 @@
       - { type: "web",                                                                 # WSGI & LAMP sites supported
           name: "tools",                                                               # Name of the dev website
           path: "/vagrant/public/vagrant-tools",                                       # Path to site home folder
-#          template: "{{playbook_dir}}/files/apache2/website.yml",                     # Provide custom template, uf builtin is not good
-          aliases: [ "tools.vagrant.dev" ],                                             # These will be additional aliases to <<name>>.lvh.me
+          # template: "{{playbook_dir}}/files/apache2/website.yml",                    # Provide custom template, uf builtin is not good
+          aliases: [ "tools.vagrant.dev" ],                                            # These will be additional aliases to <<name>>.lvh.me
           vhost_overrides: ["SetEnv no-gzip 1", "RequestHeader unset Accept-Encoding"] # These lines will be added to website configuration file.
         }
 
@@ -35,11 +35,12 @@
      - include: "{{root_dir}}/tasks_apache.yml"                                     # apache prefork|worker
      - include: "{{root_dir}}/tasks_php_apt_switchversion.yml"                      # Selects preferred php family
      - include: "{{root_dir}}/tasks_php_apache.yml"                                 # php 5.5 for apache
-     - include: "{{root_dir}}/tasks_nodejs.yml"                                     # node 0.12.*
+     - include: "{{root_dir}}/tasks_nodejs.yml"                                     # node 6.x
      - include: "{{root_dir}}/tasks_memcached.yml"                                  # installs memcached service
-     - include: "{{root_dir}}/tools/tasks_mailhog.yml"
+     - include: "{{root_dir}}/tasks_sendmail.yml"                                   # Sendmail
+     - include: "{{root_dir}}/tools/tasks_mailhog.yml"                              # Mailhog
      - include: "./tasks_phpextensions.yml"                                         # Installs custom php extensions
-     - include: "{{root_dir}}/vagrant/tasks_vagrant_php_webgrind.yml"                   # Webgrind
+     - include: "{{root_dir}}/vagrant/tasks_vagrant_php_webgrind.yml"               # Webgrind
      - include: "{{root_dir}}/vagrant/tasks_vagrant_phpmyadmin.yml"                 # PhpMyAdmin
      - include: "{{root_dir}}/vagrant/tasks_vagrant_php_xdebug.yml"                 # XDebug extension
      - include: "{{root_dir}}/vagrant/tasks_vagrant_write_tools.yml"                # db import script, python venv init scripts


### PR DESCRIPTION
This PR includes:
- Fix a `var not found` error in the php extensions task
- Update the nodejs version to use 6.x family by default. (Asuming that it's ok to set a more up to date version of nodejs)
- Update ansible syntak to use `become`
- Adds a sendmail task, needed to send emails with php
- Minor indentation updates

My environment for testing these changes is:

```
Vagrant 1.9.1
ansible 2.2.1.0
```

Thanks